### PR TITLE
Feat: 멤버중 교수자 - 강좌 사이의 M:N 관계를 현재 임명된 교수자 테이블 `TEACH_LECTURE`로 해소함.

### DIFF
--- a/src/main/java/com/MateStudy/MateStudy/domain/homework/File_homework.java
+++ b/src/main/java/com/MateStudy/MateStudy/domain/homework/File_homework.java
@@ -1,0 +1,7 @@
+package com.MateStudy.MateStudy.domain.homework;
+
+/**
+ * 부여된 실습과제 엔티티와 File 엔티티간의 관계
+ */
+public class File_homework {
+}

--- a/src/main/java/com/MateStudy/MateStudy/domain/homework/Homework.java
+++ b/src/main/java/com/MateStudy/MateStudy/domain/homework/Homework.java
@@ -1,0 +1,13 @@
+package com.MateStudy.MateStudy.domain.homework;
+
+import com.MateStudy.MateStudy.domain.common.BaseEntity;
+
+/**
+ *  등록된 실습이 갖는 여러 과제들의  관계
+ *  MEMBER_LECTURE : QUESTION
+ *  Maximum cardinality 1:N
+ *  Minimum cardinality M:O
+ */
+public class Homework extends BaseEntity {
+
+}

--- a/src/main/java/com/MateStudy/MateStudy/domain/lecture/Lecture.java
+++ b/src/main/java/com/MateStudy/MateStudy/domain/lecture/Lecture.java
@@ -1,0 +1,31 @@
+package com.MateStudy.MateStudy.domain.lecture;
+
+import com.MateStudy.MateStudy.domain.common.BaseEntity;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+@Table(name = "LECTURE")
+@IdClass(LectureId.class)
+public class Lecture extends BaseEntity {
+    /*Composit key를 이용하여 직렬화 필요*/
+
+    @Id
+    @Column(name="lecCode")
+    private String lecCode; // 학수번호
+
+    @Id
+    @Column(name="subCode")
+    private long subCode; // 분반번호
+
+    @Column(nullable = false)
+    private String lecTitle;
+
+}

--- a/src/main/java/com/MateStudy/MateStudy/domain/lecture/LectureId.java
+++ b/src/main/java/com/MateStudy/MateStudy/domain/lecture/LectureId.java
@@ -1,0 +1,26 @@
+package com.MateStudy.MateStudy.domain.lecture;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Id;
+import java.io.Serializable;
+
+/**
+ * Spring Data JPA에서 RDBMS의 composite key 표현을 위해 직렬화
+ */
+
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@NoArgsConstructor
+public class LectureId implements Serializable {
+    //private static final serialVersionUID; 사용안하면 class의 기본 해시값 사용함
+    @EqualsAndHashCode.Include
+    @Id
+    protected String lecCode; // 학수번호
+    @EqualsAndHashCode.Include
+    @Id
+    protected long subCode; // 분반번호
+}

--- a/src/main/java/com/MateStudy/MateStudy/domain/lecture/Taking_Lecture.java
+++ b/src/main/java/com/MateStudy/MateStudy/domain/lecture/Taking_Lecture.java
@@ -1,0 +1,4 @@
+package com.MateStudy.MateStudy.domain.lecture;
+
+public class Taking_Lecture {
+}

--- a/src/main/java/com/MateStudy/MateStudy/domain/lecture/TeachingLecId.java
+++ b/src/main/java/com/MateStudy/MateStudy/domain/lecture/TeachingLecId.java
@@ -1,0 +1,22 @@
+package com.MateStudy.MateStudy.domain.lecture;
+
+import com.MateStudy.MateStudy.domain.account.Member;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.io.Serializable;
+
+@NoArgsConstructor
+@AllArgsConstructor
+public class TeachingLecId implements Serializable {
+    //private static final serialVersionUID; 사용안하면 class의 기본 해시값 사용함\
+
+    protected String instId;
+
+    protected String lecCode;
+
+    protected long subCode;
+
+}

--- a/src/main/java/com/MateStudy/MateStudy/domain/lecture/Teaching_Lecture.java
+++ b/src/main/java/com/MateStudy/MateStudy/domain/lecture/Teaching_Lecture.java
@@ -1,0 +1,47 @@
+package com.MateStudy.MateStudy.domain.lecture;
+
+import com.MateStudy.MateStudy.domain.account.Member;
+import com.MateStudy.MateStudy.domain.common.BaseEntity;
+import lombok.*;
+
+import javax.persistence.*;
+
+/**
+ * 관리자가 생성 및 교원 임명
+ * 또는 교수가 생성한 강좌에 대해
+ * Member_lecture에 멤버(학생, 교원) - 실습강의의 mapping 관계 형성
+ */
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString(exclude = {"instId", "lecCode", "subCode"}) // 성능을 위해 fetch Lazy 타입으로 종종한다. 이때 사용
+@Table(name = "TEACH_LECTURE")
+@IdClass(TeachingLecId.class)
+public class Teaching_Lecture extends BaseEntity {
+    /* MEMBER 엔티티와 맵핑( 교수자를 가르킴) */
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "instId")
+    private Member instId;
+
+    /* LECTURE 엔티티와 맵핑 (등록되어있는 실습 강좌의 학수번호 가르킴 */
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    //@JoinColumn(name = "instLecCode")
+    @JoinColumns({
+            @JoinColumn(name = "lecCode", referencedColumnName = "lecCode",insertable = false, updatable = false),
+            @JoinColumn(name = "subCode", referencedColumnName = "subCode",insertable = false, updatable = false)
+    })
+    private Lecture lec;
+
+    /* LECTURE 엔티티와 맵핑 (등록되어있는 실습 강좌의 분반정보 가르킴)*/
+    @Column(name="lecCode")
+    private String lecCode;
+
+    @Column(name="subCode")
+    private long subCode;
+
+}

--- a/src/main/java/com/MateStudy/MateStudy/domain/question/Question.java
+++ b/src/main/java/com/MateStudy/MateStudy/domain/question/Question.java
@@ -1,0 +1,11 @@
+package com.MateStudy.MateStudy.domain.question;
+
+import com.MateStudy.MateStudy.domain.common.BaseEntity;
+
+/**
+ * 등록된 실습에서 한 학생이 갖는 여러 질문들을 처리
+ * MEMBER_LECTURE : QUESTION  Maximum cardinality 1:N
+ */
+public class Question {
+
+}

--- a/src/main/java/com/MateStudy/MateStudy/repository/lecture/LectureRepository.java
+++ b/src/main/java/com/MateStudy/MateStudy/repository/lecture/LectureRepository.java
@@ -1,0 +1,21 @@
+package com.MateStudy.MateStudy.repository.lecture;
+
+import com.MateStudy.MateStudy.domain.lecture.Lecture;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface LectureRepository extends JpaRepository<Lecture, String> {
+
+    /* 학수번호-분반정보를 통해 현재 등록된 실습 정보가 있는지 반환 */
+    @Query(value="SELECT DISTINCT L FROM Lecture L WHERE L.lecCode = :lecCode")
+    List<Lecture> getLectures(@Param("lecCode") String lecCode);
+
+
+    /* 학수번호-분반정보를 통해 지정하기 위해 강좌 정보를 데이터베이스로부터 반환*/
+    @Query(value = "SELECT L FROM Lecture L WHERE L.lecCode= :lecCode AND L.subCode = :subCode")
+    Optional<Lecture> getOneLecture(@Param("lecCode") String lecCode, @Param("subCode") Long subCode);
+}

--- a/src/main/java/com/MateStudy/MateStudy/repository/lecture/TakeLectureRepository.java
+++ b/src/main/java/com/MateStudy/MateStudy/repository/lecture/TakeLectureRepository.java
@@ -1,0 +1,5 @@
+package com.MateStudy.MateStudy.repository.lecture;
+
+public interface TakeLectureRepository {
+
+}

--- a/src/main/java/com/MateStudy/MateStudy/repository/lecture/TeachLectureRepository.java
+++ b/src/main/java/com/MateStudy/MateStudy/repository/lecture/TeachLectureRepository.java
@@ -1,0 +1,19 @@
+package com.MateStudy.MateStudy.repository.lecture;
+
+import com.MateStudy.MateStudy.domain.lecture.Teaching_Lecture;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+/**
+ * 교수자 - 강좌를 맵핑한 Teacing_Lecture에 관한 Spring Data JPA 연동
+ */
+public interface TeachLectureRepository extends JpaRepository<Teaching_Lecture, String> {
+
+    /* 교수자에게 강좌를 지정하기 위해 강좌 정보를 데이터베이스로부터 가져옴 */
+    @Query(value = "SELECT L FROM Lecture L WHERE L.lecCode= :lecCode AND L.subCode = :subCode")
+    Optional<Teaching_Lecture> getLectureToAssign(@Param("lecCode") String lecCode, @Param("subCode") Long subCode);
+
+}

--- a/src/main/java/com/MateStudy/MateStudy/service/lecture/LectureService.java
+++ b/src/main/java/com/MateStudy/MateStudy/service/lecture/LectureService.java
@@ -1,0 +1,39 @@
+package com.MateStudy.MateStudy.service.lecture;
+
+import com.MateStudy.MateStudy.domain.lecture.Lecture;
+import com.MateStudy.MateStudy.repository.MemberRepository;
+import com.MateStudy.MateStudy.repository.lecture.LectureRepository;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Slf4j
+@AllArgsConstructor
+public class LectureService {
+
+    @Autowired
+    private LectureRepository lecRepository;
+
+    /* 학수번호, 분반정보로 강의 찾기
+    * Lecture 엔티티는 fetch 방법이 LazyType이라 Transactional로 데이터베이스 연결 이후에도 접근하게끔
+    *  */
+    @Transactional
+    public boolean isExistByLecCode(String lectureCode){
+        log.info("> isLecturesExist? ");
+        List<Lecture> list = lecRepository.getLectures(lectureCode);
+        return !list.isEmpty();
+    }
+
+    @Transactional
+    public boolean isExistByWholeCode(String lectureCode, long subCode){
+        log.info("> isLectureExist? ");
+        Optional<Lecture> lecture = lecRepository.getOneLecture(lectureCode, subCode);
+        return lecture.isPresent();
+    }
+}

--- a/src/main/java/com/MateStudy/MateStudy/service/lecture/TakeLectureService.java
+++ b/src/main/java/com/MateStudy/MateStudy/service/lecture/TakeLectureService.java
@@ -1,0 +1,4 @@
+package com.MateStudy.MateStudy.service.lecture;
+
+public class TakeLectureService {
+}

--- a/src/main/java/com/MateStudy/MateStudy/service/lecture/TeachLectureService.java
+++ b/src/main/java/com/MateStudy/MateStudy/service/lecture/TeachLectureService.java
@@ -1,0 +1,52 @@
+package com.MateStudy.MateStudy.service.lecture;
+
+import com.MateStudy.MateStudy.domain.account.Member;
+import com.MateStudy.MateStudy.domain.lecture.Lecture;
+import com.MateStudy.MateStudy.domain.lecture.Teaching_Lecture;
+import com.MateStudy.MateStudy.repository.MemberRepository;
+import com.MateStudy.MateStudy.repository.lecture.LectureRepository;
+import com.MateStudy.MateStudy.repository.lecture.TeachLectureRepository;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.Optional;
+
+/**
+ * 강좌 - 교수자 Repository를 활용하여 서비스 제공
+ */
+@Service
+@Slf4j
+@AllArgsConstructor
+public class TeachLectureService {
+
+    @Autowired
+    TeachLectureRepository teachingRepository;
+
+    @Autowired
+    LectureRepository lectureRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    /* 교수자의 학번, 등록하고자 하는 학수번호, 분반 정보 입력시 "학습 중 강좌"에 교수자 등록*/
+    @Transactional
+    public void setInstructor(String id, String lecCode, long subCode){
+        Optional<Lecture> lecture = lectureRepository.getOneLecture(lecCode, subCode);
+        Optional<Member> instructor = memberRepository.findByName(id);
+
+        if(lecture.isPresent() && instructor.isPresent()){
+            Teaching_Lecture result = Teaching_Lecture.builder()
+                    .instId(instructor.get())
+                    .lecCode(lecture.get().getLecCode())
+                    .subCode(lecture.get().getSubCode())
+                    .build();
+            teachingRepository.save(result);
+        }else{
+            log.info("강좌에 교수자 지정 실패");
+        }
+    }
+
+}

--- a/src/test/java/com/MateStudy/MateStudy/repository/LectureRepositoryTest.java
+++ b/src/test/java/com/MateStudy/MateStudy/repository/LectureRepositoryTest.java
@@ -1,0 +1,58 @@
+package com.MateStudy.MateStudy.repository;
+
+import com.MateStudy.MateStudy.domain.lecture.Lecture;
+import com.MateStudy.MateStudy.repository.lecture.LectureRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@SpringBootTest
+public class LectureRepositoryTest {
+    @Autowired
+    LectureRepository lectureRepository;
+
+    /**
+     * 최준호
+     * 강좌 도메인과 관련하여 JPA Repositroy를 상속받은 UserRepositroy의 의존성 주입이 잘 되는지 테스트
+     */
+    @Test
+    public void testClass() {
+        log.info("Test case : 강좌 도메인 관련 JPA Repository 의존성 주입 테스트");
+        String proxyName = lectureRepository.getClass().getName();
+        log.info("result : " + proxyName);
+        Assertions.assertNotNull(proxyName);
+    }
+
+    /**
+     * 최준호
+     * 강좌 정보 CREATE
+     */
+    @Test
+    @Transactional
+    public void testInsertLecture() {
+        log.info("INSERT DUMMY MEMBER INTO THE DATABASE");
+        boolean testStatus = false;
+        try {
+            final int SIZE = 5;
+            String[] dummyLecCode = {"CSE4058", "CSE4058", "CSE4036", "CSE4036", "CSE4041", "CSE4041", "CSE4038", "CSE4038"};
+            long[] dummySubCode = {1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L,};
+            String[] dummyTitle = {"소프트웨어공학개론", "소프트웨어공학개론", "인공지능", "인공지능",
+                    "데이터베이스프로그래밍", "데이터베이스프로그래밍", "데이터통신입문", "데이터통신입문"};
+            for (int i = 0; i < SIZE; i++) {
+                Lecture lecture = Lecture.builder().lecCode(dummyLecCode[i]).subCode(dummySubCode[i])
+                        .lecTitle(dummyTitle[i]).build();
+                lectureRepository.save(lecture);
+            }
+            log.info("DONE");
+            testStatus = true;
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            Assertions.assertTrue(testStatus);
+        }
+    }
+}

--- a/src/test/java/com/MateStudy/MateStudy/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/MateStudy/MateStudy/repository/MemberRepositoryTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -17,19 +18,25 @@ public class MemberRepositoryTest {
     @Autowired
     MemberRepository memRepository;
 
-    /** 최준호
+    /**
+     * 최준호
      * 회원 도메인과 관련하여 JPA Repositroy를 상속받은 UserRepositroy의 의존성 주입이 잘 되는지 테스트
      */
     @Test
-    public void testClass(){
+    public void testClass() {
         log.info("Test case : 회원 도메인 관련 JPA Repository 의존성 주입 테스트");
         String proxyName = memRepository.getClass().getName();
         Assertions.assertNotNull(proxyName);
         log.info("result : " + proxyName);
     }
 
+    /**
+     * 최준호
+     * Member 테이블에 데이터 삽입하는 테스트케이스, 그냥실행하면 데이터 갱신됨
+     * commit;안하려면 @Test 어노테이션 밑이나 위에 @Transactional 작성해주자
+     */
     @Test
-    public void testStudentSignUp(){
+    public void testStudentSignUp() {
         log.info("INSERT DUMMY MEMBER INTO THE DATABASE");
         final int LENGTH = 4;
         BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
@@ -38,9 +45,9 @@ public class MemberRepositoryTest {
         String[] dummyIdInfo = {"2017110000", "2016112000", "2017112001", "2017112002"};
         String[] dummyNameInfo = {"최학생", "김학생", "이학생", "범학생"};
         String[] dummyEmailInfo = {"stdTest@test.com", "stdTest2@test.kr", "stdTest3@test.com", "stdTest4@test.com"};
-        String[] dummyPhoneInfo = {"010-1200-0000", "010-1200-0001", "010-1200-0002", "010-1200-0003" };
+        String[] dummyPhoneInfo = {"010-1200-0000", "010-1200-0001", "010-1200-0002", "010-1200-0003"};
 
-        for(int i = 0; i<LENGTH; i++){
+        for (int i = 0; i < LENGTH; i++) {
             Member member = Member.builder().id(dummyIdInfo[i]).pwd(passwordEncoder.encode("1234"))
                     .name(dummyNameInfo[i]).email(dummyEmailInfo[i]).phone(dummyPhoneInfo[i]).build();
             member.addMemberRole(MemberRole.STUDENT);
@@ -50,7 +57,7 @@ public class MemberRepositoryTest {
     }
 
     @Test
-    public void testInstructorSignUp(){
+    public void testInstructorSignUp() {
         log.info("INSERT DUMMY MEMBER INTO THE DATABASE");
         final int LENGTH = 4;
         BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
@@ -58,9 +65,9 @@ public class MemberRepositoryTest {
         String[] dummyIdInfo = {"2017120000", "2017120001", "2017120002", "2017120003"};
         String[] dummyNameInfo = {"김교수", "이교수", "최교수", "김교수"};
         String[] dummyEmailInfo = {"kimProfTest@test.com", "leeProfTest@test.com", "choiProfTest@test.com", "kimProfTest@test.com"};
-        String[] dummyPhoneInfo = {"010-1234-5678", "010-1234-5679", "010-1234-5670", "010-1234-5671" };
+        String[] dummyPhoneInfo = {"010-1234-5678", "010-1234-5679", "010-1234-5670", "010-1234-5671"};
 
-        for(int i = 0; i<LENGTH; i++){
+        for (int i = 0; i < LENGTH; i++) {
             Member member = Member.builder().id(dummyIdInfo[i]).pwd(passwordEncoder.encode("1234"))
                     .name(dummyNameInfo[i]).email(dummyEmailInfo[i]).phone(dummyPhoneInfo[i]).build();
             member.addMemberRole(MemberRole.INSTRUCTOR);
@@ -70,16 +77,18 @@ public class MemberRepositoryTest {
     }
 
     @Test
-    public void testAdminSignUp(){
+    public void testAdminSignUp() {
         log.info("INSERT DUMMY MEMBER INTO THE DATABASE");
         final int LENGTH = 4;
         BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
         /*
-        * 최초 실행시 1번,
-        * 현재는 개인정보 노출을 피하고자 제거해놓은 상태
-        *
-        * */
+         * 최초 실행시 1번,
+         * 현재는 개인정보 노출을 피하고자 제거해놓은 상태
+         *
+         * */
+
+        /* INSERT INFO HERE */
 
         /*for(int i = 0; i<LENGTH; i++){
             Member member = Member.builder().id(dummyIdInfo[i]).pwd(passwordEncoder.encode("1234"))
@@ -91,7 +100,8 @@ public class MemberRepositoryTest {
     }
 
     @Test
-    public void testFindById(){
+    @Transactional
+    public void testFindById() {
         Optional<Member> result = memRepository.findById("2017112095");
         Member member = result.get();
         log.info(member.toString());

--- a/src/test/java/com/MateStudy/MateStudy/service/LectureServiceTest.java
+++ b/src/test/java/com/MateStudy/MateStudy/service/LectureServiceTest.java
@@ -1,0 +1,55 @@
+package com.MateStudy.MateStudy.service;
+
+import com.MateStudy.MateStudy.service.lecture.LectureService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.transaction.Transactional;
+
+@Slf4j
+@SpringBootTest
+public class LectureServiceTest {
+
+    @Autowired
+    LectureService lectureService;
+
+    /**
+     * 최준호
+     * Service에 대한 의존성 주입이 잘되는지 테스트
+     */
+    @Test
+    public void testClass() {
+        String proxyName = lectureService.getClass().getName();
+        Assertions.assertNotNull(proxyName);
+    }
+
+    /**
+     * 최준호
+     * 강좌 학수번호 정보로 갖고 올 수 있는지 확인
+     */
+    @Transactional
+    @Test
+    public void testGetLectures() {
+        log.info("Test : 학수번호 정보로 갖고 올 수 있는지 확인");
+        String lecCode = "CSE4058";
+        boolean testStatus = lectureService.isExistByLecCode(lecCode);
+        Assertions.assertTrue(testStatus);
+    }
+
+    /**
+     * 최준호
+     * 강좌 학수번호-분반정보로 정보를 갖고 올 수 있는지 확인
+     */
+    @Transactional
+    @Test
+    public void testGetLecture() {
+        log.info("Test : 학수번호-분반정보로 정보를 갖고 올 수 있는지 확인");
+        String lecCode = "CSE4058";
+        long subCOde = 1L;
+        boolean testStatus = lectureService.isExistByWholeCode(lecCode, subCOde);
+        Assertions.assertTrue(testStatus);
+    }
+}

--- a/src/test/java/com/MateStudy/MateStudy/service/TeachLectureServiceTest.java
+++ b/src/test/java/com/MateStudy/MateStudy/service/TeachLectureServiceTest.java
@@ -1,0 +1,87 @@
+package com.MateStudy.MateStudy.service;
+
+import com.MateStudy.MateStudy.domain.account.Member;
+import com.MateStudy.MateStudy.domain.lecture.Lecture;
+import com.MateStudy.MateStudy.domain.lecture.Teaching_Lecture;
+import com.MateStudy.MateStudy.repository.MemberRepository;
+import com.MateStudy.MateStudy.repository.lecture.LectureRepository;
+import com.MateStudy.MateStudy.repository.lecture.TeachLectureRepository;
+import com.MateStudy.MateStudy.service.lecture.TeachLectureService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.transaction.TestTransaction;
+
+import javax.transaction.Transactional;
+import java.util.Optional;
+
+@Slf4j
+@SpringBootTest
+public class TeachLectureServiceTest {
+
+    @Autowired
+    LectureRepository lectureRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    TeachLectureRepository teachingRepository;
+
+
+    @Test
+    public void testLectureClass() {
+        log.info("Test case : Lecture 도메인 관련 JPA Repository 의존성 주입 테스트");
+        String proxyName = lectureRepository.getClass().getName();
+        log.info("result : " + proxyName);
+        Assertions.assertNotNull(proxyName);
+    }
+
+    @Test
+    public void testMemberClass() {
+        log.info("Test case : Member 도메인 관련 JPA Repository 의존성 주입 테스트");
+        String proxyName = memberRepository.getClass().getName();
+        log.info("result : " + proxyName);
+        Assertions.assertNotNull(proxyName);
+    }
+
+    @Test
+    public void testTeachingClass() {
+        log.info("Test case : Member 도메인 관련 JPA Repository 의존성 주입 테스트");
+        String proxyName = teachingRepository.getClass().getName();
+        log.info("result : " + proxyName);
+        Assertions.assertNotNull(proxyName);
+    }
+
+    /* 강좌에 교수자 임명 테스트케이스 */
+    @Test
+    @Transactional
+    public void testSetInstructor(){
+        boolean testStatus = false;
+        Optional<Lecture> lecture = lectureRepository.getOneLecture("CSE4058", 1L);
+        log.info(lecture.toString());
+        Optional<Member> instructor = memberRepository.findById("2017120002");
+        log.info(instructor.toString());
+        if(lecture.isPresent() && instructor.isPresent()){
+            Teaching_Lecture result = Teaching_Lecture.builder()
+                    .instId(instructor.get())
+                    .lecCode(lecture.get().getLecCode())
+                    .subCode(lecture.get().getSubCode())
+                    .build();
+            teachingRepository.save(result);
+            testStatus = true;
+        }else{
+            log.info("강좌에 교수자 지정 실패");
+        }
+        /**
+         * 현재 성능을 위해 데이터베이스 fetch 모드가 Lazy인데 여러 repository에 걸친 질의의 경우,
+         * 하나의 Transcation으로 처리하기 위해 @Transional 필요
+         * 이때 테스트케이스라면, commit; 하지않고 rollback; 하여 명시적으로 아래에 코드 작성함.
+         */
+        //TestTransaction.flagForCommit();
+        Assertions.assertTrue(testStatus);
+    }
+
+}


### PR DESCRIPTION
DB 구조는 Pull Request를 참조

### 요약
> 교수자 강좌에 임명하여 현재 진행 중인 실습 강좌를 지정할 수 있도록 함. 


#### 0. ER다이어그램 
![image](https://user-images.githubusercontent.com/54317409/143081765-eeb7d6b6-6c83-4baa-91ba-bab99ebbc8a8.png)

 
#### 1.  MEMBER 테이블 중 교수자와 강좌 사이의 M:N 관계를 `TEACH_LECTURE` 로 해소함


#### 2. main 패키지 내 작업 내용 
- main/.../domain 패키지 의 lecture 부분 참고
- `Lecture.java` : Lecture 엔티티
- `LectureId.java` Lecture 엔티티는 composite key로 이루어져 있어서 Seriliazable하게 구현할 필요가 있었다.
- `Teaching_Lecture.java` : 등록된 강좌에 교수자를 임명
- `TeachingLecId.java` : composite key 로 이루어져 있어서 Seriliazable하게 구현할 필요가 있었다.

#### 3. Test 패키지 내 작업 내용
##### Repository 관련 테스트 
- `LectureRepository.java`
  - 의존성 주입 체크 및
  - 강좌 정보 CREATE 
-`MemberRepository.java` 
  - 의존성 주입 체크
  - `Member`테이블에 학생, 교수자, 관리자 데이터 삽입하는 케이스
  - 학번으로 조회하는 테스트케이스
 ##### Serivce 관련 테스트
- `LectureServiceTest.java`
  - 강좌 학수번호 정보로 강좌 데이터를 읽을 수 있는지 테스트
  - 강좌 학수번호 및 분반 정보로 강좌 데이터 정보를 읽을 수 있는지 테스트 

#### 4. DB 현황
- `LECTURE` 테이블
![image](https://user-images.githubusercontent.com/54317409/143082963-7da8940e-92e8-4342-b6dc-ec09ed4febdb.png)

- `TEACH_LECTURE` 테이블
![image](https://user-images.githubusercontent.com/54317409/143083147-f50cc68c-99fb-4be3-b335-baf5397fd890.png)

