### PR TITLE
Feat: 출석 관련 DB 생성

### DIFF
--- a/src/main/java/com/MateStudy/MateStudy/controller/Lecture/LectureController.java
+++ b/src/main/java/com/MateStudy/MateStudy/controller/Lecture/LectureController.java
@@ -28,4 +28,5 @@ public class LectureController {
         model.addAttribute("postList", lectureDtoList);
         return "lecture/lecture-admin";
     }
+
 }

--- a/src/main/java/com/MateStudy/MateStudy/controller/attendance/AttendanceController.java
+++ b/src/main/java/com/MateStudy/MateStudy/controller/attendance/AttendanceController.java
@@ -1,6 +1,7 @@
 package com.MateStudy.MateStudy.controller.attendance;
 
 import com.MateStudy.MateStudy.dto.Lecture.LectureDto;
+import com.MateStudy.MateStudy.dto.MemberDto;
 import com.MateStudy.MateStudy.dto.security.CustomedMemberDTO;
 import com.MateStudy.MateStudy.service.lecture.LectureService;
 import com.MateStudy.MateStudy.service.lecture.TakeLectureService;
@@ -34,7 +35,6 @@ public class AttendanceController {
     @Autowired
     private TakeLectureService takeLectureService;
 
-
     /* 실습 관리자 출석 관리 */
     @GetMapping("/attendance-admin")
     public String attendAdmin(@AuthenticationPrincipal CustomedMemberDTO cmDTO, Model model){
@@ -45,11 +45,25 @@ public class AttendanceController {
         /* 그외 비즈니스 로직 호출 후 Model 객체에 담아서 뷰로 전달 */
         /* 1. 해당 멤버의 담당 과목 - 사실 해당 페이지는 관리자용 페이지라 여기서 검증하는건 두번 검증하는 거긴 하다. */
         List<LectureDto> lectureDtoList = new ArrayList<>();
+        List<MemberDto> initMemberDtos = new ArrayList<>();
+        String initLecTitle = "";
         if(role.equals("[INSTRUCTOR]")){
             lectureDtoList= teachLectureService.getLectureDtoList(cmDTO.getId());
+            /* 초기화면의 관리 학생 화면 */
+            log.info(lectureDtoList.toString());
+            log.info(lectureDtoList.get(0).toString());
+            initLecTitle = lectureDtoList.get(0).getLecTitle();
+            String initLecCode = lectureDtoList.get(0).getLecCode();
+            Long initSubCode= lectureDtoList.get(0).getSubCode();
+            initLecTitle += "_"+initSubCode;
+            initMemberDtos = teachLectureService.getMyStudents(cmDTO.getId(), initLecCode, initSubCode);
+            log.info(initMemberDtos.toString());
         }else if(role.equals("[STUDENT]")){
             lectureDtoList = takeLectureService.getLectureDtoList(cmDTO.getId());
         }
+
+        /* 2. 자신이 관리하는 모든 학생 정보 */
+
 
         /* 기본 인적 사항 관련 */
         model.addAttribute("id", id);
@@ -58,7 +72,9 @@ public class AttendanceController {
 
         /* right-sidebar에서 필요한 담당 과목 정보*/
         model.addAttribute("lectures", lectureDtoList);
-
+        /* 자신이 관리하는 학생들 */
+        model.addAttribute("initStudents", initMemberDtos);
+        model.addAttribute("initLecTitle", initLecTitle);
         return "attendance/attend-admin";
     }
 

--- a/src/main/java/com/MateStudy/MateStudy/domain/attendance/Attend.java
+++ b/src/main/java/com/MateStudy/MateStudy/domain/attendance/Attend.java
@@ -1,0 +1,51 @@
+package com.MateStudy.MateStudy.domain.attendance;
+
+import com.MateStudy.MateStudy.domain.common.BaseEntity;
+import com.MateStudy.MateStudy.domain.lecture.Taking_Lecture;
+import lombok.*;
+
+import javax.persistence.*;
+
+/**
+ * 실습에 참여한 학생들을 관리하는 엔티티
+ */
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString(exclude = {}) // 성능을 위해 fetch Lazy 타입으로 종종한다. 이때 사용
+@Table(name = "ATTENDANCE")
+public class Attend extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO) // hwId를 추가하면 따로 Id 등록안해서 자동으로 생성하게끔
+    private Long attendId;
+
+    /* TAKE_LECTURE 엔티티와 맵핑 - 강의를 듣는 학생이 가지는 제출한 과제들 */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumns({
+            @JoinColumn(name = "instId", referencedColumnName = "instId",insertable = false, updatable = false),
+            @JoinColumn(name = "lecCode", referencedColumnName = "lecCode",insertable = false, updatable = false),
+            @JoinColumn(name = "subCode", referencedColumnName = "subCode",insertable = false, updatable = false),
+            @JoinColumn(name = "stId", nullable = true, referencedColumnName = "stId", insertable = false, updatable = false)
+    })
+    private Taking_Lecture t_lec;
+
+    @Column(name="instId", nullable = false)
+    private String instId;
+    @Column(name="lecCode", nullable = false)
+    private String lecCode;
+    @Column(name="subCode", nullable = false)
+    private Long subCode;
+
+    /* 해당 과목에서 주차 정보등을 담는다 */
+    @Column(name="week")
+    private Long week;
+
+    /* 출석 여부 yet, attend, late, absence, vacancy */
+    @Column(name="status", columnDefinition = "varchar(255) DEFAULT 'YET' CHECK (status IN ('YET', 'ATTEND', 'LATE', 'ABSENCE', 'VACANCY'))")
+    private String status;
+}

--- a/src/main/java/com/MateStudy/MateStudy/domain/homework/Submit_Homework.java
+++ b/src/main/java/com/MateStudy/MateStudy/domain/homework/Submit_Homework.java
@@ -31,7 +31,7 @@ public class Submit_Homework extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.AUTO) // hwId를 추가하면 따로 Id 등록안해도 자동으로 생성하게끔
     private Long submitId; // Wrapper 클래스인 Long 쓰는 이유, long과 같은 primitive 타입의 기본값은 0인데, 데이터베이스에서 데이터가 없다는 의미인지, id가 0인지 혼동
 
-    /* TAKE_LECUTE 엔티티의 stId - 등록된 실습 강좌에 속하는 학생이 등록하는 과제 */
+    /* ASSIGN_HOMEWORK 엔티티와 맵핑 - 강의에서 부여한 과제들 */
     /*@ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "stId", nullable = true)
     private Taking_Lecture stId;*/
@@ -39,7 +39,7 @@ public class Submit_Homework extends BaseEntity {
     @JoinColumn(name = "hwId", nullable = false)
     private Assign_Homework hwId;
 
-    /* TEACH_LECTURE 엔티티와 맵핑 (등록되어있는 실습 강좌에서 등록한 과제 */
+    /* TAKE_LECTURE 엔티티와 맵핑 - 강의를 듣는 학생이 가지는 제출한 과제들 */
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumns({
             @JoinColumn(name = "instId", referencedColumnName = "instId",insertable = false, updatable = false),

--- a/src/main/java/com/MateStudy/MateStudy/repository/MemberRepository.java
+++ b/src/main/java/com/MateStudy/MateStudy/repository/MemberRepository.java
@@ -2,9 +2,12 @@ package com.MateStudy.MateStudy.repository;
 
 import com.MateStudy.MateStudy.domain.account.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -24,4 +27,14 @@ public interface MemberRepository extends JpaRepository<Member, String> {
      *  SQL의 where구문에 대해 파라미터 바인딩 기능 제공한다.
      *  Native SQL 처리를 할 수 있다. JPA 를 사용하는 장점은 잃을 수 있으나, 복잡한 JOIN 구문을 처리하기 위해 사용된다.
      * */
+
+    /* 해당 강좌에 속한 학생들의 정보 반환 */
+    @Query(value="SELECT M FROM Member M WHERE M.id IN (SELECT tl.stId FROM Taking_Lecture tl WHERE tl.instId=:instId AND tl.lecCode=:lecCode AND tl.subCode=:subCode)")
+    List<Member> getClassStudents(@Param("instId") String instId, @Param("lecCode") String lecCode, @Param("subCode") Long subCode);
+
+    /* 교수자에게 속한 모든 학생들 정보 반환*/
+    @Query(value="SELECT M FROM Member M WHERE M.id IN (SELECT tl.stId FROM Taking_Lecture tl WHERE tl.instId=:instId)")
+    List<Member> getMyStudents(@Param("instId") String instId);
+
+
 }

--- a/src/main/java/com/MateStudy/MateStudy/repository/attend/AttendRepository.java
+++ b/src/main/java/com/MateStudy/MateStudy/repository/attend/AttendRepository.java
@@ -1,0 +1,4 @@
+package com.MateStudy.MateStudy.repository.attend;
+
+public interface AttendRepository {
+}

--- a/src/main/java/com/MateStudy/MateStudy/service/lecture/TeachLectureService.java
+++ b/src/main/java/com/MateStudy/MateStudy/service/lecture/TeachLectureService.java
@@ -7,6 +7,7 @@ import com.MateStudy.MateStudy.domain.lecture.Teaching_Lecture;
 import com.MateStudy.MateStudy.dto.Lecture.Assign_HomeworkDto;
 import com.MateStudy.MateStudy.dto.Lecture.LectureDto;
 import com.MateStudy.MateStudy.dto.Lecture.TeachLectureDto;
+import com.MateStudy.MateStudy.dto.MemberDto;
 import com.MateStudy.MateStudy.repository.MemberRepository;
 import com.MateStudy.MateStudy.repository.lecture.Assign_HomeworkRepository;
 import com.MateStudy.MateStudy.repository.lecture.LectureRepository;
@@ -119,7 +120,7 @@ public class TeachLectureService {
 
     /* 교수자의 학번, 등록하고자 하는 학수번호, 분반 정보 입력시 "학습 중 강좌"에 교수자 등록*/
     @Transactional
-    public void setInstructor(String id, String lecCode, long subCode){
+    public void setInstructor(String id, String lecCode, Long subCode){
         Optional<Lecture> lecture = lectureRepository.getOneLecture(lecCode, subCode);
         Optional<Member> instructor = memberRepository.findByName(id);
 
@@ -136,4 +137,36 @@ public class TeachLectureService {
         }
     }
 
+    /* 교수자, 학수번호, 분반번호로 관리하는 모든 학생 정보 반환 */
+    @Transactional
+    public List<MemberDto> getMyStudents(String instId, String lecCode, Long subCode){
+       List<Member> students = memberRepository.getClassStudents(instId, lecCode, subCode);
+       List<MemberDto> dtos = new ArrayList<>();
+       for(Member s: students){
+           /* 비밀번호는 보안상 굳이 담지 않았다. */
+           MemberDto memberDto = MemberDto.builder()
+                   .id(s.getId())
+                   .name(s.getName())
+                   .phone(s.getPhone())
+                   .build();
+           dtos.add(memberDto);
+       }
+       return dtos;
+    }
+    /* 교수자 정보로 자신이 담당하는 모든 학생 정보 반환 */
+    @Transactional
+    public List<MemberDto> getClassStudents(String instId){
+        List<Member> students = memberRepository.getMyStudents(instId);
+        List<MemberDto> dtos = new ArrayList<>();
+        for(Member s: students){
+            /* 비밀번호는 보안상 굳이 담지 않았다. */
+            MemberDto memberDto = MemberDto.builder()
+                    .id(s.getId())
+                    .name(s.getName())
+                    .phone(s.getPhone())
+                    .build();
+            dtos.add(memberDto);
+        }
+        return dtos;
+    }
 }

--- a/src/main/resources/templates/attendance/attend-Lecture.html
+++ b/src/main/resources/templates/attendance/attend-Lecture.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.w3.org/1999/xhtml">
+<!-- 과제 타임라인 / 관리 학생 현황 -->
+<div th:fragment="lecture-timeline" class="timeline" >
+    <!-- 과제1 today(red) -->
+    <div class="col-xl-3 col-md-6 mb-4" th:each="lecture : ${lectures}">
+        <div class="card border-left-danger shadow h-100 py-2">
+            <div class="card-body">
+                <div class="row no-gutters align-items-center">
+                    <div class="col mr-2">
+                        <div class="text-xs font-weight-bold text-uppercase mb-1"
+                             th:text="${lecture.lecTitle} +'_'+${lecture.subCode}"> 과목명 분반 </div>
+                    </div>
+                    <div class="col-auto">
+                        <i class="far fa-calendar-check fa-2x text-gray-300"></i>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- 학생 클래스별 출석률  -->
+<div th:fragment="lecture-attendRateStudent" class="row">
+    <div class="col-lg-12 mb-0">
+        <div class="card shadow mb-4">
+            <div class="card-header py-3">
+                <h6 class="m-0 font-weight-bold text-primary">클래스별 출석률</h6>
+            </div>
+            <div class="card-body" th:each="lecture : ${lectures}">
+                <h4 class="small font-weight-bold" th:text="${lecture.lecTitle} +'_'+${lecture.subCode}">수업 정보<span
+                        class="float-right">40%</span></h4>
+                <div class="progress mb-4">
+                    <div class="progress-bar bg-info progress-bar-striped progress-bar-animated" role="progressbar" style="width: 40%"
+                         aria-valuenow="40" aria-valuemin="0" aria-valuemax="100"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- 관리자 클래스별 출석률  -->
+<div th:fragment="lecture-attendRateAdmin" class="row">
+    <div class="col-lg-12 mb-0">
+        <div class="card shadow mb-4">
+            <div class="card-header py-3">
+                <h6 class="m-0 font-weight-bold text-primary">클래스별 출석률</h6>
+            </div>
+            <div class="card-body" th:each="lecture : ${lectures}">
+                <h4 class="small font-weight-bold" th:text="${lecture.lecTitle} +'_'+${lecture.subCode}">수업 정보<span
+                        class="float-right">40%</span></h4>
+                <div class="progress mb-4">
+                    <div class="progress-bar bg-info progress-bar-striped progress-bar-animated" role="progressbar" style="width: 40%"
+                         aria-valuenow="40" aria-valuemin="0" aria-valuemax="100"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/main/resources/templates/attendance/attend-admin.html
+++ b/src/main/resources/templates/attendance/attend-admin.html
@@ -8,110 +8,109 @@
 <!-- Page Wrapper -->
 <div id="wrapper">
 
-  <!-- 왼쪽 사이드바 -->
-  <ul th:replace="fragments/left-sidebar.html :: ul"></ul>
+    <!-- 왼쪽 사이드바 -->
+    <ul th:replace="fragments/left-sidebar.html :: ul"></ul>
 
-  <!-- Content Wrapper -->
-  <div id="content-wrapper" class="d-flex flex-column">
+    <!-- Content Wrapper -->
+    <div id="content-wrapper" class="d-flex flex-column">
 
-    <!-- Main Content -->
-    <div id="content">
+        <!-- Main Content -->
+        <div id="content">
 
-      <!-- ********************** 이름 어떻게 하는지 모르겠어요 ***************************** -->
-      <nav th:replace="fragments/topbar.html :: nav(${name})"></nav>
+            <!-- ********************** 이름 어떻게 하는지 모르겠어요 ***************************** -->
+            <nav th:replace="fragments/topbar.html :: nav(${name})"></nav>
 
-      <!-- Begin Page Content -->
-      <div class="container-fluid">
+            <!-- Begin Page Content -->
+            <div class="container-fluid">
 
-        <!-- 출석률 -->
-        <div class="d-sm-flex align-items-center justify-content-between mb-4">
-          <h1 class="h3 mb-0 text-gray-800">출석률</h1>
-          <button th:align="right">새로고침</button>
-        </div>
-
-        <!-- 출석률, 바 그래프 -->
-        <div class="row">
-          <div class="col-lg-12 mb-0">
-            <div class="card shadow mb-4">
-              <div class="card-header py-3">
-                <h6 class="m-0 font-weight-bold text-primary">클래스별 출석률</h6>
-              </div>
-              <div class="card-body">
-                <h4 class="small font-weight-bold">수업1 <span
-                        class="float-right">40%</span></h4>
-                <div class="progress mb-4">
-                  <div class="progress-bar bg-warning" role="progressbar" style="width: 40%"
-                       aria-valuenow="40" aria-valuemin="0" aria-valuemax="100"></div>
+                <!-- 출석률 -->
+                <div class="d-sm-flex align-items-center justify-content-between mb-4">
+                   <!-- <h1 class="h3 mb-0 text-gray-800">출석률</h1>-->
+                    <button th:align="right">새로고침</button>
                 </div>
-                <h4 class="small font-weight-bold">수업2 <span
-                        class="float-right">60%</span></h4>
-                <div class="progress mb-4">
-                  <div class="progress-bar" role="progressbar" style="width: 60%"
-                       aria-valuenow="60" aria-valuemin="0" aria-valuemax="100"></div>
+
+                <!-- 상단에 출석 관련된 과목 보여줌 -->
+                <!--<div th:replace="attendance/attend-Lecture.html :: lecture-timeline"></div>-->
+
+                <!-- 출석률, 바 그래프 -->
+                <div th:replace="attendance/attend-Lecture.html :: lecture-attendRateAdmin"></div>
+
+                <!-- Content Row -->
+                <hr class="sidebar-divider">
+
+                <!-- 달력 -->
+                <div class="d-sm-flex align-items-center justify-content-between mb-4">
+                    <h5 class="h3 mb-0 text-gray-800" th:text="${initLecTitle}+' 담당 학생 출석 조회'">담당 학생 출석 체크</h5>
                 </div>
-                <h4 class="small font-weight-bold">수업3 <span
-                        class="float-right">100%</span></h4>
-                <div class="progress">
-                  <div class="progress-bar bg-success" role="progressbar" style="width: 100%"
-                       aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"></div>
+                <!-- Content Row -->
+                <div class="row">
+                    <div class="table-responsive">
+                        <form action="/#" method="post">
+                            <table class="table table-bordered" id="dataTable" width="100%" cellspacing="0">
+                                <thead>
+                                <tr>
+                                    <th style="width: 10%">이름</th>
+                                    <th style="width: 30%">학번</th>
+                                    <th style="width: 30%">출석 여부</th>
+                                    <th style="width: 30%">출석 관리</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr th:each="initStudent: ${initStudents}">
+                                    <input type="hidden" th:name="${_csrf.parameterName}"
+                                           th:value="${_csrf.token}"/>
+                                    <!--<input type="hidden" th:name="submitId" th:value="${homework.submitId}"/>-->
+                                    <td th:text="${initStudent.name}">김범규</td>
+                                    <td th:text="${initStudent.id}">2017112083</td>
+                                    <!--<td th:if="${i}" ></td>-->
+                                    <td>미정</td>
+                                    <td>
+                                        <div class="row">
+                                            <div class="col-8">
+                                                <label>
+                                                    <select name="attend">
+                                                        <option value="attend">출석</option>
+                                                        <option value="late">지각</option>
+                                                        <option value="absence">결석</option>
+                                                        <option value="vacancy">공결</option>
+                                                    </select>
+                                                </label>
+                                            </div>
+                                        </div>
+
+                                    </td>
+                                </tr>
+
+                                </tbody>
+                            </table>
+                            <!-- 수정 필요 -->
+                            <div class="col-4" style="margin: auto">
+                                <button type="submit" class="btn btn-primary" style="width:50%">갱신</button>
+                            </div>
+                        </form>
+                    </div>
                 </div>
-              </div>
+
             </div>
-          </div>
+            <!-- /.container-fluid -->
+
         </div>
+        <!-- End of Main Content -->
 
-        <!-- Content Row -->
-        <hr class="sidebar-divider">
-
-        <!-- 달력 -->
-        <div class="d-sm-flex align-items-center justify-content-between mb-4">
-          <h1 class="h3 mb-0 text-gray-800">출석 체크</h1>
-        </div>
-        <!-- Content Row -->
-        <div class="row">
-
-          <form id="frm" action="action.jsp">
-            <p>수업:</p>
-            <select>
-              <option value="class1">수업1</option>
-              <option value="class2">수업2</option>
-              <option value="class3">수업3</option>
-            </select>
-            <br/>
-            <p>출석정보:</p>
-            <div>
-              <input type="date" id="userdate" name="userdate"
-                     value="2021-11-29">
-              <select>
-                <option value="attend">출석</option>
-                <option value="late">지각</option>
-                <option value="absent">결석</option>
-              </select>
-              <input type="submit" value="변경">
-            </div>
-          </form>
-        </div>
-
-      </div>
-      <!-- /.container-fluid -->
-
+        <!-- Footer -->
+        <footer th:replace="fragments/footer.html :: footer"></footer>
     </div>
-    <!-- End of Main Content -->
+    <!-- End of Content Wrapper -->
 
-    <!-- Footer -->
-    <footer th:replace="fragments/footer.html :: footer"></footer>
-  </div>
-  <!-- End of Content Wrapper -->
-
-  <!-- 오른쪽 사이드바 -->
-  <ul th:replace="fragments/right-sidebar.html :: ul"></ul>
+    <!-- 오른쪽 사이드바 -->
+    <ul th:replace="fragments/right-sidebar.html :: ul"></ul>
 
 </div>
 <!-- End of Page Wrapper -->
 
 <!-- Scroll to Top Button-->
 <a class="scroll-to-top rounded" href="#page-top">
-  <i class="fas fa-angle-up"></i>
+    <i class="fas fa-angle-up"></i>
 </a>
 
 <!-- Logout Modal-->

--- a/src/main/resources/templates/attendance/attend-student.html
+++ b/src/main/resources/templates/attendance/attend-student.html
@@ -29,8 +29,12 @@
                     <button th:align="right">새로고침</button>
                 </div>
 
+                <!-- 출석 과목 전체 조회-->
+                <!--<div th:replace="attendance/attend-Lecture.html :: lecture-timeline"></div>-->
                 <!-- 출석률, 바 그래프 -->
-                <div class="row">
+                <div th:replace="attendance/attend-Lecture.html :: lecture-attendRateStudent"></div>
+
+                <!--<div class="row">
                     <div class="col-lg-12 mb-0">
                         <div class="card shadow mb-4">
                             <div class="card-header py-3">
@@ -58,14 +62,14 @@
                             </div>
                         </div>
                     </div>
-                </div>
+                </div>-->
 
                 <!-- Content Row -->
                 <hr class="sidebar-divider">
 
                 <!-- 달력 -->
                 <div class="d-sm-flex align-items-center justify-content-between mb-4">
-                    <h1 class="h3 mb-0 text-gray-800">출석 체크</h1>
+                    <h1 class="h3 mb-0 text-gray-800">출석 체크 상세 조회</h1>
                 </div>
 
                 <div>

--- a/src/test/java/com/MateStudy/MateStudy/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/MateStudy/MateStudy/repository/MemberRepositoryTest.java
@@ -14,6 +14,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Optional;
 
 @Slf4j
@@ -146,4 +147,30 @@ public class MemberRepositoryTest {
         Member member = result.get();
         log.info(member.toString());
     }
+
+
+    /* 교수자가 관리하는 모든 학생 정보 반환 테스트*/
+    @Test
+    @Transactional
+    public void testGetMyStudents(){
+        String instId="2017120002";
+        List<Member> memberList = memRepository.getMyStudents(instId);
+        for(Member member : memberList){
+            log.info(member.getName());
+        }
+    }
+
+    /* 교수자, 학수번호, 분반 정보로 해당 강좌의 학생 반환 테스트 */
+    @Test
+    @Transactional
+    public void testGetClassStudents(){
+        String instId = "2017120002";
+        String lecCode = "CSE4036";
+        Long subCode = 1L;
+        List<Member> memberList = memRepository.getClassStudents(instId, lecCode, subCode);
+        for (Member member : memberList){
+            log.info(member.getName());
+        }
+    }
+
 }

--- a/src/test/java/com/MateStudy/MateStudy/service/TakeLectureServiceTest.java
+++ b/src/test/java/com/MateStudy/MateStudy/service/TakeLectureServiceTest.java
@@ -45,9 +45,9 @@ public class TakeLectureServiceTest {
     public void testSetStudent() {
         boolean testStatus = false;
         String[] dummyIdInfo = {"2017112095", "2016112144", "2017112129", "2017112083"};
-        String instId = "2017120003";
-        String lecCode = "CSE4038";
-        Long subCode = 2L;
+        String instId = "2017120002";
+        String lecCode = "CSE4036";
+        Long subCode = 1L;
         try {
             for (String s : dummyIdInfo) {
                 takeLectureService.setStudent(s, instId, lecCode, subCode);


### PR DESCRIPTION
### 1. 출석 데이터베이스
컬럼명 : classweek , 데이터타입 BigInt 
컬럼명 : status, 데이터타입 varchar(256), default 값 'YET' CHECK 제약조건 status in ('YET', 'ATTEND', 'LATE', 'ABSENCE', 'VACANY')
![image](https://user-images.githubusercontent.com/54317409/143934159-45b2698b-9a51-4ea8-b208-1701dd98699d.png)

### 2. 관리자 출석 조회
- 초기 페이지 이동시 제일 첫 과목의 학생들을 불러옴
- 주차별로 나눠서 해야하는데 고민이 됨
- 다른 과목 선택시 바뀌게 하고 싶은데 이것도 고민이 됨 
![s1](https://user-images.githubusercontent.com/54317409/143934376-1cbb6bed-aa53-4636-b26e-10f9f81b236f.PNG)

### 3. 학생 출석 조회
- 과목별로 선택하면 다르게 하고 싶은데 이것도 고민이 됨
![image](https://user-images.githubusercontent.com/54317409/143934459-51151c8d-82eb-4b23-b3b5-3d0a16d67f34.png)


